### PR TITLE
Python 3 fixes

### DIFF
--- a/lldbinit.py
+++ b/lldbinit.py
@@ -90,7 +90,7 @@ except:
     pass
 
 VERSION = "2.0"
-BUILD = "206"
+BUILD = "207"
 
 #
 # User configurable options
@@ -1915,6 +1915,7 @@ def cmd_findmem(debugger, command, result, dict):
     parser.add_argument("-q", "--qword",   help="Find qword (native packing)")
     parser.add_argument("-f", "--file" ,   help="Load find pattern from file")
     parser.add_argument("-c", "--count",   help="How many occurances to find, default is all")
+    parser.add_argument("--min-range",   help="Do not search memory regions which start before this range", type=auto_int)
     parser.add_argument("--max-range",   help="Do not search memory regions which start passed this range", type=auto_int)
 
     parser = parser.parse_args(arg.split())
@@ -1981,6 +1982,11 @@ def cmd_findmem(debugger, command, result, dict):
         mem_end   = int(mem_range.split(b"-")[1], 16)
 
         # make sure we are within expected search range
+        if parser.min_range is not None:
+            if mem_end < parser.min_range:
+                continue
+            if mem_start < parser.min_range:
+                mem_start = parser.min_range
         if parser.max_range is not None:
             if mem_start > parser.max_range:
                 continue

--- a/lldbinit.py
+++ b/lldbinit.py
@@ -1960,16 +1960,16 @@ def cmd_findmem(debugger, command, result, dict):
     process = get_process()
     pid = process.GetProcessID()
     output_data = subprocess.check_output(["/usr/bin/vmmap", "%d" % pid])
-    #print(output_data)
     lines = output_data.split(b"\n")
-    #print(lines);
     # this relies on output from /usr/bin/vmmap so code is dependant on that 
     # only reason why it's used is for better description of regions, which is
     # nice to have. If they change vmmap in the future, I'll use my version 
     # and that output is much easier to parse...
     newlines = []
     for x in lines:
-        #p = re.compile(b"([\S\s]+)\s([\da-fA-F]{16}-[\da-fA-F]{16}|[\da-fA-F]{8}-[\da-fA-F]{8})")
+        # this regex creates 2 capture groups
+        # the first will find the first non-whitespace sequence in the row
+        # the second will grab any hex ranges, each between 8 and 16 characters long
         p = re.compile(b"^(\S+)\s+([\da-fA-F]{8,16}-[\da-fA-F]{8,16})")
         m = p.search(x)
         if not m: continue
@@ -2010,8 +2010,6 @@ def cmd_findmem(debugger, command, result, dict):
                 
         membuff = process.ReadMemory(mem_start, mem_size, err)
         if err.Success() == False:
-            #output(str(err));
-            #result.PutCString("".join(GlobalListOutput));
             continue
         off = 0
         base_displayed = 0
@@ -2050,8 +2048,8 @@ def cmd_findmem(debugger, command, result, dict):
                     output(" " * 8)
                 else:
                     output(" " * 16)
-            #well if somebody allocated 4GB of course offset will be too small to fit here
-            #but who cares...
+            # well if somebody allocated 4GB of course offset will be too small to fit here
+            # but who cares...
             output(" off : %.08X %s" % (off, mem_name))
             print("".join(GlobalListOutput))
             membuff = membuff[idx+len(search_string):]

--- a/lldbinit.py
+++ b/lldbinit.py
@@ -1909,8 +1909,7 @@ def cmd_findmem(debugger, command, result, dict):
 
     arg = str(command)
     parser = argparse.ArgumentParser(prog="lldb")
-    parser.add_argument("-s", "--string",  help="Search string")
-    parser.add_argument("-u", "--unicode", help="Search unicode string")
+    parser.add_argument("-s", "--string",  help="Search unicode string")
     parser.add_argument("-b", "--binary",  help="Serach binary string")
     parser.add_argument("-d", "--dword",   help="Find dword (native packing)")
     parser.add_argument("-q", "--qword",   help="Find qword (native packing)")
@@ -1921,11 +1920,11 @@ def cmd_findmem(debugger, command, result, dict):
     parser = parser.parse_args(arg.split())
     
     if parser.string is not None:
-        search_string = parser.string
-    elif parser.unicode is not None:
-        search_string  = unicode(parser.unicode)
+        search_string = parser.string.encode('utf-8')
     elif parser.binary is not None:
-        search_string = parser.binary.decode("hex")
+        if parser.binary[0:2] == "0x":
+            parser.binary = parser.binary[2:]
+        search_string = bytes.fromhex(parser.binary)
     elif parser.dword is not None:
         dword = evaluate(parser.dword)
         if dword is None:
@@ -2020,7 +2019,7 @@ def cmd_findmem(debugger, command, result, dict):
         while True:
             if count == 0: 
                 return
-            idx = membuff.find(search_string.encode('utf-8'))
+            idx = membuff.find(search_string)
             if idx == -1: 
                 break
             if count != -1:

--- a/lldbinit.py
+++ b/lldbinit.py
@@ -2097,7 +2097,7 @@ Note: expressions supported, do not use spaces between operators.
 # ----------------------------------------------------------
 
 def get_arch():
-    return lldb.debugger.GetSelectedTarget().triple.split(b'-')[0]
+    return lldb.debugger.GetSelectedTarget().triple.split('-')[0]
 
 #return frame for stopped thread... there should be one at least...
 def get_frame():

--- a/lldbinit.py
+++ b/lldbinit.py
@@ -2002,9 +2002,6 @@ def cmd_findmem(debugger, command, result, dict):
         mem_start= x[1]
         mem_end  = x[2]
         mem_size = mem_end - mem_start
-
-        #print ("%s  %s  %s" % (mem_name, mem_start, mem_end))
-        #continue
     
         err = lldb.SBError()
                 


### PR DESCRIPTION
lldb-1205.0.27.3 had some problems running `findmem` since it now relies on Python 3. I made a few tweaks so `findmem` will work again. While I was at it, I added two new switches for `findmem` to help restrict searching within overlapping memory regions if you need it.