### PR TITLE
Added support for the antidebug command on arm64

### DIFF
--- a/lldbinit.py
+++ b/lldbinit.py
@@ -865,7 +865,7 @@ def cmd_antidebug(debugger, command, result, dict):
     '''Enable anti-anti-debugging. Use \'antidebug help\' for more information.'''
     help = """
 Enable anti-anti-debugging measures.
-Bypasses sysctl AmIBeingDebugged debugger detection.
+Bypasses sysctl/ptrace/task_get_exception_ports/task_set_exception_ports debugger detection.
 
 Syntax: antidebug
 """


### PR DESCRIPTION
This PR can add the support for the antidebug command on arm64.
It also supports antidebug bypass methods against the use of ptrace, task_get_exception, and task_set_exception.
I am not familiar with lldb python scripting, so there may be a better implementation.
