### PR TITLE
fix indentation

### DIFF
--- a/lldbinit.py
+++ b/lldbinit.py
@@ -2241,10 +2241,10 @@ Syntax: crackcmd_noret <address> <register> <value>
             return
     elif is_i386():
         valid = [ "eip", "eax", "ebx", "ebp", "esp", "edi", "esi", "edx", "ecx" ]
-    if register not in valid:
+        if register not in valid:
             print("[-] error: invalid register for i386 architecture.")
-        print(help)
-        return
+            print(help)
+            return
 
     if value is None:
         print("[-] error: invalid value.")
@@ -5515,7 +5515,7 @@ def HandleHookStopOnTarget(debugger, command, result, dict):
 
     # if we stopped because of a breakpoint try to extract which was it so we can display the name if it exists
     bp_name = ""
-        thread = frame.GetThread()
+    thread = frame.GetThread()
     stop_reason = thread.GetStopReason()
     if stop_reason == lldb.eStopReasonBreakpoint:
         if thread.GetStopReasonDataCount() > 0:


### PR DESCRIPTION
before 
```
➜  lldbinit git:(master) lldb
error: module importing failed: Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/fp/lldbinit.py", line 2246
    print(help)
               ^
IndentationError: unindent does not match any outer indentation level
(lldb) quit
➜  lldbinit git:(master) lldb
error: module importing failed: Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/fp/lldbinit.py", line 5518
    thread = frame.GetThread()
IndentationError: unexpected indent
(lldb) quit
```

after

```
➜  lldbinit git:(master) lldb
[!] current terminal size is 80x24
[!] lldbinit is best experienced with a terminal size at least 125x25
[+] Loaded lldbinit version 3.1.383
(lldbinit) quit
```