### PR TITLE
Fixed the invalid escape sequence '\s' error

### DIFF
--- a/lldbinit.py
+++ b/lldbinit.py
@@ -3784,7 +3784,7 @@ def dump_conditionalaarch64(cpsr):
             # x = re.search('([a-z0-9]{2,3})', operands)
             # extract each operand - they are comma separated
             # cb have two, tb three operands
-            x = re.findall("[^,\s]+", operands)
+            x = re.findall("[^,\\s]+", operands)
             # if we can't read the operands it's an error
             if x is None:
                 return taken, reason


### PR DESCRIPTION
When lldb sources the `lldb.py` on `Ubuntu 24.04`, the following error has occured.
```sh
SyntaxWarning: invalid escape sequence '\s'
  x = re.findall("[^,\s]+", operands)
```
 This issue can be fixed by appending a backslash.
